### PR TITLE
Load scripts and styles only on plugin pages

### DIFF
--- a/wp-pepipost.php
+++ b/wp-pepipost.php
@@ -69,7 +69,7 @@ endif;
  * This function used to enqueue the required script files
  */
 function wp_pepipost_scripts_method() {
-	if ( is_admin() ) {
+    if ( false !== strpos( $hook, 'wp_pepipost' )  ) {
 		
 		wp_register_style( 'wp-pepipost', plugin_dir_url( __FILE__ ). 'css/wp-pepipost-ui.css', false, '1.11.4' );
 		wp_enqueue_style( 'wp-pepipost' );


### PR DESCRIPTION
No necessary to use `is_admin()` check because `admin_enqueue_scripts` granted this.
Instead of this we checking that current page is related to pepipost plugin settings page. 
So, pepipost plugin scripts and styles will be loaded only in place where they really needed.